### PR TITLE
fix(reqLogger): prevent `destroyed` socket race

### DIFF
--- a/src/telemetry/requestLogger.ts
+++ b/src/telemetry/requestLogger.ts
@@ -80,10 +80,11 @@ function finishLog<SLocals extends AnyServiceLocals = ServiceLocals<Configuratio
   }
   const [url, preInfo] = getBasicInfo(req);
 
-  let responseType = 'finished';
+  let responseType = 'unknown';
 
-  // ts warning is known and incorrect—`aborted` is a subset of `destroyed`
-  if (req.aborted) {
+  if (res.writableFinished) {
+    responseType = 'finished';
+  } else if (req.aborted) {
     responseType = 'aborted';
   } else if (req.destroyed) {
     responseType = 'destroyed';


### PR DESCRIPTION
Always set the socket response type to `finished` when `finished` is called. Prevents a race where `finished` sockets _sometimes_ get logged as `destroyed` (since all sockets are eventually `destroyed`, even when they sent a response successfully).