### PR TITLE
feat:(INFRA-1108): expanding existing http metrics to include new metrics, labels and types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@ coverage
 /tsconfig.build.json
 /.prettierrc.yaml
 /vitest.config.ts
+
+#configs
+.DS_Store
+.commitlintrc.json
+.eslintignore
+.eslintrc.cjs
+.npmignore
+.prettierrc.cjs

--- a/src/express-app/app.ts
+++ b/src/express-app/app.ts
@@ -149,8 +149,11 @@ export async function startApp<
   const histogram = app.locals.meter.createHistogram('http_request_duration_seconds', {
     description: 'Duration of HTTP requests in seconds',
   });
+  const requestCounter = app.locals.meter.createCounter('http_requests_total', {
+    description: 'Total number of HTTP requests',
+  });
 
-  app.use(loggerMiddleware(app, histogram, logging));
+  app.use(loggerMiddleware(app, histogram, requestCounter, logging));
 
   // Allow the service to add locals, etc. We put this before the body parsers
   // so that the req can decide whether to save the raw request body or not.
@@ -280,7 +283,7 @@ export async function startApp<
     app.use(notFoundMiddleware());
   }
   if (errors?.enabled) {
-    app.use(errorHandlerMiddleware(app, histogram, errors?.unnest, errors?.render));
+    app.use(errorHandlerMiddleware(app, histogram, requestCounter, errors?.unnest, errors?.render));
   }
 
   return app;

--- a/src/telemetry/requestLogger.ts
+++ b/src/telemetry/requestLogger.ts
@@ -104,7 +104,8 @@ function finishLog<SLocals extends AnyServiceLocals = ServiceLocals<Configuratio
     dur,
   };
 
-  histogram.record(dur, { method });
+  const routePath = req.route?.path || req.path || url;
+  histogram.record(dur, { method, status_code: String(status), path: routePath, service: app.locals.name });
   counter.add(1, { code: String(status), method });
 
   if (res.locals.user?.id) {

--- a/src/telemetry/requestLogger.ts
+++ b/src/telemetry/requestLogger.ts
@@ -105,7 +105,7 @@ function finishLog<SLocals extends AnyServiceLocals = ServiceLocals<Configuratio
   };
 
   const routePath = req.route?.path || req.path || url;
-  histogram.record(dur, { method, status_code: String(status), path: routePath, service: app.locals.name });
+  histogram.record(dur, { status_code: String(status), method, path: routePath, service: app.locals.name });
   counter.add(1, { code: String(status), method });
 
   if (res.locals.user?.id) {

--- a/src/telemetry/requestLogger.ts
+++ b/src/telemetry/requestLogger.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler, Request, Response, ErrorRequestHandler } from 'express';
 import { getClientIp } from 'request-ip';
-import type { Histogram } from '@opentelemetry/api';
+import type { Counter, Histogram } from '@opentelemetry/api';
 import cleanStack from 'clean-stack';
 
 import { ServiceError } from '../error.js';
@@ -60,6 +60,7 @@ function finishLog<SLocals extends AnyServiceLocals = ServiceLocals<Configuratio
   req: Request,
   res: Response & { [LOGGED_SEMAPHORE]?: boolean },
   histogram: Histogram,
+  counter: Counter,
 ) {
   if (res[LOGGED_SEMAPHORE]) {
     return;
@@ -92,21 +93,19 @@ function finishLog<SLocals extends AnyServiceLocals = ServiceLocals<Configuratio
     responseType = 'errored';
   }
 
+  const status = (error as ErrorWithStatus)?.status || res.statusCode || 0;
+  const method = req.method;
+
   const endLog: Record<string, string | string[] | number | undefined> = {
     ...preInfo,
     t: 'req',
     r: responseType,
-    s: (error as ErrorWithStatus)?.status || res.statusCode || 0,
+    s: status,
     dur,
   };
 
-  const path = req.route ? { path: req.route.path } : undefined;
-  histogram.record(dur, {
-    status_code: endLog.s,
-    method: endLog.m,
-    ...path,
-    service: app.locals.name,
-  });
+  histogram.record(dur, { method });
+  counter.add(1, { code: String(status), method });
 
   if (res.locals.user?.id) {
     endLog.u = res.locals.user.id;
@@ -159,6 +158,7 @@ export function loggerMiddleware<
 >(
   app: ServiceExpress<SLocals>,
   histogram: Histogram,
+  counter: Counter,
   config?: ConfigurationSchema['logging'],
 ): RequestHandler {
   const nonProd = getNodeEnv() !== 'production';
@@ -210,7 +210,7 @@ export function loggerMiddleware<
       }
     }
 
-    const logWriter = (err?: Error) => finishLog(app, err, req, res, histogram);
+    const logWriter = (err?: Error) => finishLog(app, err, req, res, histogram, counter);
     res.on('finish', logWriter);
     res.on('close', logWriter);
     res.on('error', logWriter);
@@ -220,7 +220,7 @@ export function loggerMiddleware<
 
 export function errorHandlerMiddleware<
   SLocals extends AnyServiceLocals = ServiceLocals<ConfigurationSchema>,
->(app: ServiceExpress<SLocals>, histogram: Histogram, unnest?: boolean, returnError?: boolean) {
+>(app: ServiceExpress<SLocals>, histogram: Histogram, counter: Counter, unnest?: boolean, returnError?: boolean) {
   const svcErrorHandler: ErrorRequestHandler = (error, req, res, next) => {
     let loggable: Partial<ServiceError> = error;
     const body = error.response?.body || error.body;
@@ -237,7 +237,7 @@ export function errorHandlerMiddleware<
     // Set the status to error, even if we aren't going to render the error.
     res.status(loggable.status || 500);
     if (returnError) {
-      finishLog(app, error as Error, req, res, histogram);
+      finishLog(app, error as Error, req, res, histogram, counter);
       const prefs = (res.locals as WithLogPrefs)[LOG_PREFS];
       prefs.logged = true;
       res.json({


### PR DESCRIPTION
Generating more metrics to gain additional application performance metrics per GCP's recs:

https://docs.cloud.google.com/kubernetes-engine/docs/how-to/app-performance-metrics
https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/exporters/server/http