### PR TITLE
feat: add errcode to `destroyed` response logger

### DIFF
--- a/src/telemetry/requestLogger.ts
+++ b/src/telemetry/requestLogger.ts
@@ -87,7 +87,8 @@ function finishLog<SLocals extends AnyServiceLocals = ServiceLocals<Configuratio
   } else if (req.aborted) {
     responseType = 'aborted';
   } else if (req.destroyed) {
-    responseType = 'destroyed';
+    const err = req?.errored || req?.socket?.errored;
+    responseType = err?.code ? `destroyed:${err.code}` : 'destroyed';
   } else if (error) {
     responseType = 'errored';
   }

--- a/src/telemetry/requestLogger.ts
+++ b/src/telemetry/requestLogger.ts
@@ -88,7 +88,7 @@ function finishLog<SLocals extends AnyServiceLocals = ServiceLocals<Configuratio
     responseType = 'aborted';
   } else if (req.destroyed) {
     const err = req?.errored || req?.socket?.errored;
-    responseType = err?.code ? `destroyed:${err.code}` : 'destroyed';
+    responseType = err && 'code' in err ? `destroyed:${err.code}` : 'destroyed';
   } else if (error) {
     responseType = 'errored';
   }


### PR DESCRIPTION
This will give us more info about who severed the connection.
